### PR TITLE
Update Python SDK version to 0.9.1

### DIFF
--- a/e2e/maker/requirements.txt
+++ b/e2e/maker/requirements.txt
@@ -1,2 +1,2 @@
-orbs-orderbook-sdk==0.9.0
+orbs-orderbook-sdk==0.9.1
 requests==2.31.0

--- a/e2e/tests/requirements.txt
+++ b/e2e/tests/requirements.txt
@@ -1,2 +1,2 @@
-orbs-orderbook-sdk==0.9.0
+orbs-orderbook-sdk==0.9.1
 pytest==7.4.4


### PR DESCRIPTION
Python SDK release includes changing EIP712 message type ordering