### PR TITLE
Service layer transactions, cancel order refactoring

### DIFF
--- a/data/redisrepo/cancel_partial_filled_order.go
+++ b/data/redisrepo/cancel_partial_filled_order.go
@@ -12,7 +12,7 @@ import (
 
 // Cancels a partial filled order.
 // Order is removed from the prices sorted set, user's order set and order hash is updated to cancelled
-// May only be called if order is not pending and partially filled
+// can be called to locked orders
 func (r *redisRepository) CancelPartialFilledOrder(ctx context.Context, order models.Order) error {
 
 	if order.IsPending() {

--- a/data/redisrepo/repository.go
+++ b/data/redisrepo/repository.go
@@ -7,15 +7,18 @@ import (
 )
 
 type redisRepository struct {
-	client redis.Cmdable
+	client  redis.Cmdable
+	txMap   map[uint]redis.Pipeliner
+	ixIndex uint
 }
 
 func NewRedisRepository(client redis.Cmdable) (*redisRepository, error) {
 	if client == nil {
 		return nil, fmt.Errorf("redis client cannot be nil")
 	}
-
+	txMap := make(map[uint]redis.Pipeliner)
 	return &redisRepository{
 		client: client,
+		txMap:  txMap,
 	}, nil
 }

--- a/data/redisrepo/tk_order_test.go
+++ b/data/redisrepo/tk_order_test.go
@@ -58,7 +58,8 @@ func TestRedisRepository_TxStartEndPerform(t *testing.T) {
 			txMap:  map[uint]redis.Pipeliner{1: pipeline},
 		}
 
-		repo.txEnd(context.Background(), 1)
+		err := repo.txEnd(context.Background(), 1)
+		assert.NoError(t, err)
 
 		assert.NoError(t, mock.ExpectationsWereMet())
 		assert.NotContains(t, repo.txMap, 1)

--- a/data/redisrepo/tk_order_test.go
+++ b/data/redisrepo/tk_order_test.go
@@ -3,6 +3,7 @@ package redisrepo
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/go-redis/redismock/v9"
 	"github.com/orbs-network/order-book/mocks"
@@ -11,7 +12,25 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestRedisRepository_TxModifyOrder(t *testing.T) {
+// Init Redis repository with a mock client and a mock tx
+func setupTest() (context.Context, redismock.ClientMock, *redisRepository) {
+	ctx := context.Background()
+	db, mock := redismock.NewClientMock()
+
+	repo := &redisRepository{
+		client: db,
+		txMap:  make(map[uint]redis.Pipeliner),
+	}
+
+	tx := db.TxPipeline()
+	txid := uint(1)
+
+	repo.txMap[txid] = tx
+
+	return ctx, mock, repo
+}
+
+func TestRedisRepository_TxStartEndPerform(t *testing.T) {
 
 	t.Run("txStart initializes a transaction", func(t *testing.T) {
 		db, mock := redismock.NewClientMock()
@@ -73,19 +92,163 @@ func TestRedisRepository_TxModifyOrder(t *testing.T) {
 	})
 }
 
-func TestRedisRepository_TxDeleteClientOID(t *testing.T) {
-	ctx := context.Background()
-	db, mock := redismock.NewClientMock()
+func TestRedisRepository_TxModifyOrder(t *testing.T) {
 
-	repo := &redisRepository{
-		client: db,
-		txMap:  make(map[uint]redis.Pipeliner),
-	}
+	ctx, mock, repo := setupTest()
 
-	tx := db.TxPipeline()
-	txid := uint(1)
+	t.Run("successfully adds order", func(t *testing.T) {
 
-	repo.txMap[txid] = tx
+		mock.ExpectTxPipeline()
+		mock.ExpectHSet(CreateOrderIDKey(mocks.Order.Id), mocks.Order.OrderToMap()).SetVal(1)
+		mock.ExpectTxPipelineExec()
+
+		err := repo.PerformTx(ctx, func(txid uint) error {
+			return repo.TxModifyOrder(ctx, txid, models.Add, mocks.Order)
+		})
+
+		assert.NoError(t, err)
+		assert.NoError(t, mock.ExpectationsWereMet())
+	})
+
+	t.Run("successfully updates order", func(t *testing.T) {
+
+		mock.ExpectTxPipeline()
+		mock.ExpectHSet(CreateOrderIDKey(mocks.Order.Id), mocks.Order.OrderToMap()).SetVal(1)
+		mock.ExpectTxPipelineExec()
+
+		err := repo.PerformTx(ctx, func(txid uint) error {
+			return repo.TxModifyOrder(ctx, txid, models.Update, mocks.Order)
+		})
+
+		assert.NoError(t, err)
+		assert.NoError(t, mock.ExpectationsWereMet())
+	})
+
+	t.Run("successfully deletes order", func(t *testing.T) {
+
+		mock.ExpectTxPipeline()
+		mock.ExpectDel(CreateOrderIDKey(mocks.Order.Id)).SetVal(1)
+		mock.ExpectTxPipelineExec()
+
+		err := repo.PerformTx(ctx, func(txid uint) error {
+			return repo.TxModifyOrder(ctx, txid, models.Remove, mocks.Order)
+		})
+
+		assert.NoError(t, err)
+		assert.NoError(t, mock.ExpectationsWereMet())
+	})
+
+	t.Run("unsupported operation", func(t *testing.T) {
+
+		err := repo.PerformTx(ctx, func(txid uint) error {
+			return repo.TxModifyOrder(ctx, txid, 99, mocks.Order)
+		})
+
+		assert.ErrorIs(t, err, models.ErrUnsupportedOperation)
+	})
+}
+
+func TestRedisRepository_TxModifyPrices(t *testing.T) {
+
+	ctx, mock, repo := setupTest()
+
+	timestamp := time.Date(2023, 10, 10, 12, 0, 0, 0, time.UTC)
+
+	t.Run("successfully adds to buy side prices key", func(t *testing.T) {
+
+		var buyOrder = models.Order{
+			Id:        orderId,
+			ClientOId: clientOId,
+			Price:     price,
+			Size:      size,
+			Symbol:    symbol,
+			Side:      models.BUY,
+			Timestamp: timestamp,
+		}
+
+		mock.ExpectTxPipeline()
+		mock.ExpectZAdd(CreateBuySidePricesKey(buyOrder.Symbol), redis.Z{
+			Score:  10.0016969392,
+			Member: buyOrder.Id.String(),
+		}).SetVal(1)
+		mock.ExpectTxPipelineExec()
+
+		err := repo.PerformTx(ctx, func(txid uint) error {
+			return repo.TxModifyPrices(ctx, txid, models.Add, buyOrder)
+		})
+
+		assert.NoError(t, err)
+		assert.NoError(t, mock.ExpectationsWereMet())
+	})
+
+	t.Run("successfully adds to sell side prices key", func(t *testing.T) {
+
+		var sellOrder = models.Order{
+			Id:        orderId,
+			ClientOId: clientOId,
+			Price:     price,
+			Size:      size,
+			Symbol:    symbol,
+			Side:      models.SELL,
+			Timestamp: timestamp,
+		}
+
+		mock.ExpectTxPipeline()
+		mock.ExpectZAdd(CreateSellSidePricesKey(sellOrder.Symbol), redis.Z{
+			Score:  10.0016969392,
+			Member: sellOrder.Id.String(),
+		}).SetVal(1)
+		mock.ExpectTxPipelineExec()
+
+		err := repo.PerformTx(ctx, func(txid uint) error {
+			return repo.TxModifyPrices(ctx, txid, models.Add, sellOrder)
+		})
+
+		assert.NoError(t, err)
+		assert.NoError(t, mock.ExpectationsWereMet())
+	})
+
+	t.Run("successfully deletes price", func(t *testing.T) {
+
+		mock.ExpectTxPipeline()
+		mock.ExpectZRem(CreateBuySidePricesKey(mocks.Order.Symbol), mocks.Order.Id.String()).SetVal(1)
+		mock.ExpectTxPipelineExec()
+
+		err := repo.PerformTx(ctx, func(txid uint) error {
+			return repo.TxModifyPrices(ctx, txid, models.Remove, mocks.Order)
+		})
+
+		assert.NoError(t, err)
+		assert.NoError(t, mock.ExpectationsWereMet())
+	})
+
+	t.Run("unsupported operation", func(t *testing.T) {
+
+		err := repo.PerformTx(ctx, func(txid uint) error {
+			return repo.TxModifyPrices(ctx, txid, 99, mocks.Order)
+		})
+
+		assert.ErrorIs(t, err, models.ErrUnsupportedOperation)
+	})
+}
+
+func TestRedisRepository_TxModifyClientOId(t *testing.T) {
+
+	ctx, mock, repo := setupTest()
+
+	t.Run("successfully adds clientOID", func(t *testing.T) {
+
+		mock.ExpectTxPipeline()
+		mock.ExpectSet(CreateClientOIDKey(mocks.Order.ClientOId), mocks.Order.Id.String(), 0).SetVal("OK")
+		mock.ExpectTxPipelineExec()
+
+		err := repo.PerformTx(ctx, func(txid uint) error {
+			return repo.TxModifyClientOId(ctx, txid, models.Add, mocks.Order)
+		})
+
+		assert.NoError(t, err)
+		assert.NoError(t, mock.ExpectationsWereMet())
+	})
 
 	t.Run("successfully deletes clientOID", func(t *testing.T) {
 
@@ -95,6 +258,140 @@ func TestRedisRepository_TxDeleteClientOID(t *testing.T) {
 
 		err := repo.PerformTx(ctx, func(txid uint) error {
 			return repo.TxModifyClientOId(ctx, txid, models.Remove, mocks.Order)
+		})
+
+		assert.NoError(t, err)
+		assert.NoError(t, mock.ExpectationsWereMet())
+	})
+
+	t.Run("unsupported operation", func(t *testing.T) {
+
+		err := repo.PerformTx(ctx, func(txid uint) error {
+			return repo.TxModifyClientOId(ctx, txid, 99, mocks.Order)
+		})
+
+		assert.ErrorIs(t, err, models.ErrUnsupportedOperation)
+	})
+}
+
+func TestRedisRepository_TxModifyUserOpenOrders(t *testing.T) {
+
+	ctx, mock, repo := setupTest()
+	timestamp := time.Date(2023, 10, 10, 12, 0, 0, 0, time.UTC)
+	order := models.Order{
+		Timestamp: timestamp,
+	}
+
+	t.Run("successfully adds user open order", func(t *testing.T) {
+
+		mock.ExpectTxPipeline()
+		mock.ExpectZAdd(CreateUserOpenOrdersKey(order.UserId), redis.Z{
+			Score:  float64(timestamp.UnixNano()),
+			Member: order.Id.String(),
+		}).SetVal(1)
+		mock.ExpectTxPipelineExec()
+
+		err := repo.PerformTx(ctx, func(txid uint) error {
+			return repo.TxModifyUserOpenOrders(ctx, txid, models.Add, order)
+		})
+
+		assert.NoError(t, err)
+		assert.NoError(t, mock.ExpectationsWereMet())
+	})
+
+	t.Run("successfully removes user open order", func(t *testing.T) {
+
+		mock.ExpectTxPipeline()
+		mock.ExpectZRem(CreateUserOpenOrdersKey(order.UserId), order.Id.String()).SetVal(1)
+		mock.ExpectTxPipelineExec()
+
+		err := repo.PerformTx(ctx, func(txid uint) error {
+			return repo.TxModifyUserOpenOrders(ctx, txid, models.Remove, order)
+		})
+
+		assert.NoError(t, err)
+		assert.NoError(t, mock.ExpectationsWereMet())
+	})
+
+	t.Run("unsupported operation", func(t *testing.T) {
+
+		err := repo.PerformTx(ctx, func(txid uint) error {
+			return repo.TxModifyUserOpenOrders(ctx, txid, 99, mocks.Order)
+		})
+
+		assert.ErrorIs(t, err, models.ErrUnsupportedOperation)
+	})
+}
+
+func TestRedisRepository_TxModifyUserFilledOrders(t *testing.T) {
+
+	ctx, mock, repo := setupTest()
+	timestamp := time.Date(2023, 10, 10, 12, 0, 0, 0, time.UTC)
+	order := models.Order{
+		Timestamp: timestamp,
+	}
+
+	t.Run("successfully adds user filled order", func(t *testing.T) {
+
+		mock.ExpectTxPipeline()
+		mock.ExpectZAdd(CreateUserFilledOrdersKey(order.UserId), redis.Z{
+			Score:  float64(timestamp.UnixNano()),
+			Member: order.Id.String(),
+		}).SetVal(1)
+		mock.ExpectTxPipelineExec()
+
+		err := repo.PerformTx(ctx, func(txid uint) error {
+			return repo.TxModifyUserFilledOrders(ctx, txid, models.Add, order)
+		})
+
+		assert.NoError(t, err)
+		assert.NoError(t, mock.ExpectationsWereMet())
+	})
+
+	t.Run("successfully removes user filled order", func(t *testing.T) {
+
+		mock.ExpectTxPipeline()
+		mock.ExpectZRem(CreateUserFilledOrdersKey(order.UserId), order.Id.String()).SetVal(1)
+		mock.ExpectTxPipelineExec()
+
+		err := repo.PerformTx(ctx, func(txid uint) error {
+			return repo.TxModifyUserFilledOrders(ctx, txid, models.Remove, order)
+		})
+
+		assert.NoError(t, err)
+		assert.NoError(t, mock.ExpectationsWereMet())
+	})
+
+	t.Run("unsupported operation", func(t *testing.T) {
+
+		err := repo.PerformTx(ctx, func(txid uint) error {
+			return repo.TxModifyUserFilledOrders(ctx, txid, 3, mocks.Order)
+		})
+
+		assert.ErrorIs(t, err, models.ErrUnsupportedOperation)
+	})
+}
+
+func TestRedisRepository_TxRemoveUnfilledOrder(t *testing.T) {
+
+	ctx, mock, repo := setupTest()
+	timestamp := time.Date(2023, 10, 10, 12, 0, 0, 0, time.UTC)
+	order := models.Order{
+		Side:      models.BUY,
+		Timestamp: timestamp,
+	}
+
+	t.Run("successfully removes unfilled order", func(t *testing.T) {
+
+		mock.ExpectTxPipeline()
+		mock.ExpectZRem(CreateBuySidePricesKey(order.Symbol), order.Id.String()).SetVal(1)
+		mock.ExpectZRem(CreateUserOpenOrdersKey(order.UserId), order.Id.String()).SetVal(1)
+		mock.ExpectDel(CreateClientOIDKey(order.ClientOId)).SetVal(1)
+		mock.ExpectDel(CreateOrderIDKey(order.Id)).SetVal(1)
+		mock.ExpectTxPipelineExec()
+
+		err := repo.PerformTx(ctx, func(txid uint) error {
+			return repo.TxRemoveUnfilledOrder(ctx, txid, order)
 		})
 
 		assert.NoError(t, err)

--- a/data/redisrepo/tk_order_test.go
+++ b/data/redisrepo/tk_order_test.go
@@ -1,0 +1,103 @@
+package redisrepo
+
+import (
+	"context"
+	"testing"
+
+	"github.com/go-redis/redismock/v9"
+	"github.com/orbs-network/order-book/mocks"
+	"github.com/orbs-network/order-book/models"
+	"github.com/redis/go-redis/v9"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRedisRepository_TxModifyOrder(t *testing.T) {
+
+	t.Run("txStart initializes a transaction", func(t *testing.T) {
+		db, mock := redismock.NewClientMock()
+
+		repo := &redisRepository{
+			client:  db,
+			txMap:   make(map[uint]redis.Pipeliner),
+			ixIndex: 0,
+		}
+
+		// Set expectations
+		mock.ExpectTxPipeline()
+
+		txid, err := repo.txStart(context.Background())
+
+		assert.NoError(t, err)
+		assert.Equal(t, uint(1), txid)
+		assert.Contains(t, repo.txMap, txid)
+	})
+
+	t.Run("txEnd executes and clears transaction", func(t *testing.T) {
+		db, mock := redismock.NewClientMock()
+		pipeline := db.TxPipeline()
+
+		repo := &redisRepository{
+			client: db,
+			txMap:  map[uint]redis.Pipeliner{1: pipeline},
+		}
+
+		repo.txEnd(context.Background(), 1)
+
+		// Check that the transaction was attempted to be executed
+		assert.NoError(t, mock.ExpectationsWereMet())
+
+		// Ensure the txMap no longer contains the transaction
+		assert.NotContains(t, repo.txMap, 1)
+	})
+
+	t.Run("PerformTx executes action within a transaction", func(t *testing.T) {
+		db, mock := redismock.NewClientMock()
+
+		repo := &redisRepository{
+			client:  db,
+			txMap:   make(map[uint]redis.Pipeliner),
+			ixIndex: 0,
+		}
+
+		actionCalled := false
+		testAction := func(txid uint) error {
+			actionCalled = true
+			return nil
+		}
+
+		err := repo.PerformTx(context.Background(), testAction)
+
+		assert.NoError(t, err)
+		assert.True(t, actionCalled)
+		assert.NoError(t, mock.ExpectationsWereMet())
+	})
+}
+
+func TestRedisRepository_TxDeleteClientOID(t *testing.T) {
+	ctx := context.Background()
+	db, mock := redismock.NewClientMock()
+
+	repo := &redisRepository{
+		client: db,
+		txMap:  make(map[uint]redis.Pipeliner),
+	}
+
+	tx := db.TxPipeline()
+	txid := uint(1)
+
+	repo.txMap[txid] = tx
+
+	t.Run("successfully deletes clientOID", func(t *testing.T) {
+
+		mock.ExpectTxPipeline()
+		mock.ExpectDel(CreateClientOIDKey(mocks.Order.ClientOId)).SetVal(1)
+		mock.ExpectTxPipelineExec()
+
+		err := repo.PerformTx(ctx, func(txid uint) error {
+			return repo.TxModifyClientOId(ctx, txid, models.Remove, mocks.Order)
+		})
+
+		assert.NoError(t, err)
+		assert.NoError(t, mock.ExpectationsWereMet())
+	})
+}

--- a/data/redisrepo/tx_order.go
+++ b/data/redisrepo/tx_order.go
@@ -73,7 +73,7 @@ func (r *redisRepository) TxModifyPrices(ctx context.Context, txid uint, operati
 			// Add order to the sorted set for that token pair
 			f64Price, _ := order.Price.Float64()
 			timestamp := float64(order.Timestamp.UTC().UnixNano()) / 1e9
-			score := f64Price + (timestamp / 1e12) // Use a combination of price and scaled timestamp so that orders with the same price are sorted by time. This should not be used for price comparison.
+			score := f64Price + (timestamp / 1e12) // Use a combination of price and scaled timestamp so that orders with the same price are sorted by time. THIS SHOULD NOT BE USED FOR PRICE COMPARISON. Rather, use the price field in the order struct.
 
 			if order.Side == models.BUY {
 				buyPricesKey := CreateBuySidePricesKey(order.Symbol)

--- a/data/redisrepo/tx_order.go
+++ b/data/redisrepo/tx_order.go
@@ -13,13 +13,15 @@ import (
 func (r *redisRepository) TxStart(ctx context.Context) (uint, error) {
 	// --- START TRANSACTION ---
 	tx := r.client.TxPipeline()
-	txid := r.ixIndex + 1
+	r.ixIndex += 1
+	txid := r.ixIndex
 	r.txMap[txid] = tx
 
 	return txid, nil
 }
 
 func (r *redisRepository) TxEnd(ctx context.Context, txid uint) {
+	// --- END TRANSACTION ---
 	if tx, ok := r.txMap[txid]; ok {
 		_, err := tx.Exec(ctx)
 		if err != nil {

--- a/data/redisrepo/tx_order.go
+++ b/data/redisrepo/tx_order.go
@@ -39,151 +39,161 @@ func (r *redisRepository) PerformTx(ctx context.Context, action func(txid uint) 
 
 // This should be used for all interactions with the `order:<id>` hash key
 func (r *redisRepository) TxModifyOrder(ctx context.Context, txid uint, operation models.Operation, order models.Order) error {
-	if tx, ok := r.txMap[txid]; ok {
-
-		switch operation {
-		case models.Add, models.Update:
-			// Store order details by order ID
-			orderIDKey := CreateOrderIDKey(order.Id)
-			orderMap := order.OrderToMap()
-			tx.HSet(ctx, orderIDKey, orderMap)
-			logctx.Debug(ctx, "TxModifyOrder add", logger.String("orderId", order.Id.String()), logger.String("orderMap", fmt.Sprintf("%v", orderMap)))
-		case models.Remove:
-			orderIDKey := CreateOrderIDKey(order.Id)
-			tx.Del(ctx, orderIDKey)
-			logctx.Debug(ctx, "TxModifyOrder remove", logger.String("orderId", order.Id.String()))
-		default:
-			logctx.Error(ctx, "TxModifyOrder unsupported operation", logger.Int("operation", int(operation)))
-			return models.ErrUnsupportedOperation
-		}
-
-		return nil
-	} else {
+	var tx redis.Pipeliner
+	var ok bool
+	if tx, ok = r.txMap[txid]; !ok {
 		logctx.Error(ctx, "TxModifyOrder txid not found", logger.Int("txid", int(txid)))
 		return models.ErrNotFound
 	}
+
+	switch operation {
+	case models.Add, models.Update:
+		// Store order details by order ID
+		orderIDKey := CreateOrderIDKey(order.Id)
+		orderMap := order.OrderToMap()
+		tx.HSet(ctx, orderIDKey, orderMap)
+		logctx.Debug(ctx, "TxModifyOrder add", logger.String("orderId", order.Id.String()), logger.String("orderMap", fmt.Sprintf("%v", orderMap)))
+	case models.Remove:
+		orderIDKey := CreateOrderIDKey(order.Id)
+		tx.Del(ctx, orderIDKey)
+		logctx.Debug(ctx, "TxModifyOrder remove", logger.String("orderId", order.Id.String()))
+	default:
+		logctx.Error(ctx, "TxModifyOrder unsupported operation", logger.Int("operation", int(operation)))
+		return models.ErrUnsupportedOperation
+	}
+
+	return nil
+
 }
 
 // This should be used for all interactions with the `prices:<symbol>:buy` and `prices:<symbol>:sell` sorted sets (used to store bid/ask prices for each token pair)
 func (r *redisRepository) TxModifyPrices(ctx context.Context, txid uint, operation models.Operation, order models.Order) error {
-	if tx, ok := r.txMap[txid]; ok {
-
-		switch operation {
-		case models.Add:
-			// Add order to the sorted set for that token pair
-			f64Price, _ := order.Price.Float64()
-			timestamp := float64(order.Timestamp.UTC().UnixNano()) / 1e9
-			score := f64Price + (timestamp / 1e12) // Use a combination of price and scaled timestamp so that orders with the same price are sorted by time. THIS SHOULD NOT BE USED FOR PRICE COMPARISON. Rather, use the price field in the order struct.
-
-			if order.Side == models.BUY {
-				buyPricesKey := CreateBuySidePricesKey(order.Symbol)
-				tx.ZAdd(ctx, buyPricesKey, redis.Z{
-					Score:  score,
-					Member: order.Id.String(),
-				})
-			} else {
-				sellPricesKey := CreateSellSidePricesKey(order.Symbol)
-				tx.ZAdd(ctx, sellPricesKey, redis.Z{
-					Score:  score,
-					Member: order.Id.String(),
-				})
-			}
-			logctx.Debug(ctx, "TxModifyPrices add", logger.String("orderId", order.Id.String()), logger.String("symbol", order.Symbol.String()), logger.String("side", order.Side.String()))
-		case models.Remove:
-			if order.Side == models.BUY {
-				buyPricesKey := CreateBuySidePricesKey(order.Symbol)
-				tx.ZRem(ctx, buyPricesKey, order.Id.String())
-			} else {
-				sellPricesKey := CreateSellSidePricesKey(order.Symbol)
-				tx.ZRem(ctx, sellPricesKey, order.Id.String())
-			}
-			logctx.Debug(ctx, "TxModifyPrices remove", logger.String("orderId", order.Id.String()), logger.String("symbol", order.Symbol.String()), logger.String("side", order.Side.String()))
-		default:
-			logctx.Error(ctx, "TxModifyPrices unsupported operation", logger.Int("operation", int(operation)))
-			return models.ErrUnsupportedOperation
-		}
-		return nil
-	} else {
+	var tx redis.Pipeliner
+	var ok bool
+	if tx, ok = r.txMap[txid]; !ok {
 		logctx.Error(ctx, "TxModifyPrices txid not found", logger.Int("txid", int(txid)))
 		return models.ErrNotFound
 	}
+
+	switch operation {
+	case models.Add:
+		// Add order to the sorted set for that token pair
+		f64Price, _ := order.Price.Float64()
+		timestamp := float64(order.Timestamp.UTC().UnixNano()) / 1e9
+		score := f64Price + (timestamp / 1e12) // Use a combination of price and scaled timestamp so that orders with the same price are sorted by time. THIS SHOULD NOT BE USED FOR PRICE COMPARISON. Rather, use the price field in the order struct.
+
+		if order.Side == models.BUY {
+			buyPricesKey := CreateBuySidePricesKey(order.Symbol)
+			tx.ZAdd(ctx, buyPricesKey, redis.Z{
+				Score:  score,
+				Member: order.Id.String(),
+			})
+		} else {
+			sellPricesKey := CreateSellSidePricesKey(order.Symbol)
+			tx.ZAdd(ctx, sellPricesKey, redis.Z{
+				Score:  score,
+				Member: order.Id.String(),
+			})
+		}
+		logctx.Debug(ctx, "TxModifyPrices add", logger.String("orderId", order.Id.String()), logger.String("symbol", order.Symbol.String()), logger.String("side", order.Side.String()))
+	case models.Remove:
+		if order.Side == models.BUY {
+			buyPricesKey := CreateBuySidePricesKey(order.Symbol)
+			tx.ZRem(ctx, buyPricesKey, order.Id.String())
+		} else {
+			sellPricesKey := CreateSellSidePricesKey(order.Symbol)
+			tx.ZRem(ctx, sellPricesKey, order.Id.String())
+		}
+		logctx.Debug(ctx, "TxModifyPrices remove", logger.String("orderId", order.Id.String()), logger.String("symbol", order.Symbol.String()), logger.String("side", order.Side.String()))
+	default:
+		logctx.Error(ctx, "TxModifyPrices unsupported operation", logger.Int("operation", int(operation)))
+		return models.ErrUnsupportedOperation
+	}
+	return nil
+
 }
 
 // This should be used for all interactions with the `clientOID:<clientOID>` hash key
 func (r *redisRepository) TxModifyClientOId(ctx context.Context, txid uint, operation models.Operation, order models.Order) error {
-	if tx, ok := r.txMap[txid]; ok {
-		switch operation {
-		case models.Add:
-			clientOIdKey := CreateClientOIDKey(order.ClientOId)
-			tx.Set(ctx, clientOIdKey, order.Id.String(), 0)
-			logctx.Debug(ctx, "ModifyClientOId add", logger.String("clientOID", order.ClientOId.String()), logger.String("orderId", order.Id.String()))
-		case models.Remove:
-			clientOIdKey := CreateClientOIDKey(order.ClientOId)
-			tx.Del(ctx, clientOIdKey)
-			logctx.Debug(ctx, "ModifyClientOId remove", logger.String("clientOID", order.ClientOId.String()), logger.String("orderId", order.Id.String()))
-		default:
-			logctx.Error(ctx, "ModifyClientOId unsupported operation", logger.Int("operation", int(operation)))
-			return models.ErrUnsupportedOperation
-		}
-		return nil
-	} else {
-		logctx.Error(ctx, "ModifyClientOId txid not found", logger.Int("txid", int(txid)))
+	var tx redis.Pipeliner
+	var ok bool
+	if tx, ok = r.txMap[txid]; !ok {
+		logctx.Error(ctx, "TxModifyClientOId txid not found", logger.Int("txid", int(txid)))
 		return models.ErrNotFound
 	}
+
+	switch operation {
+	case models.Add:
+		clientOIdKey := CreateClientOIDKey(order.ClientOId)
+		tx.Set(ctx, clientOIdKey, order.Id.String(), 0)
+		logctx.Debug(ctx, "ModifyClientOId add", logger.String("clientOID", order.ClientOId.String()), logger.String("orderId", order.Id.String()))
+	case models.Remove:
+		clientOIdKey := CreateClientOIDKey(order.ClientOId)
+		tx.Del(ctx, clientOIdKey)
+		logctx.Debug(ctx, "ModifyClientOId remove", logger.String("clientOID", order.ClientOId.String()), logger.String("orderId", order.Id.String()))
+	default:
+		logctx.Error(ctx, "ModifyClientOId unsupported operation", logger.Int("operation", int(operation)))
+		return models.ErrUnsupportedOperation
+	}
+	return nil
 }
 
 // This should be used for all interactions with the `user:<userId>:openOrders` sorted set (used to store open orders for each user)
 func (r *redisRepository) TxModifyUserOpenOrders(ctx context.Context, txid uint, operation models.Operation, order models.Order) error {
-	if tx, ok := r.txMap[txid]; ok {
-		switch operation {
-		case models.Add:
-			userOrdersKey := CreateUserOpenOrdersKey(order.UserId)
-			userOrdersScore := float64(order.Timestamp.UTC().UnixNano())
-			tx.ZAdd(ctx, userOrdersKey, redis.Z{
-				Score:  userOrdersScore,
-				Member: order.Id.String(),
-			})
-			logctx.Debug(ctx, "ModifyUserOpenOrders add", logger.String("orderId", order.Id.String()), logger.String("userId", order.UserId.String()))
-		case models.Remove:
-			userOrdersKey := CreateUserOpenOrdersKey(order.UserId)
-			tx.ZRem(ctx, userOrdersKey, order.Id.String())
-			logctx.Debug(ctx, "ModifyUserOpenOrders remove", logger.String("orderId", order.Id.String()), logger.String("userId", order.UserId.String()))
-		default:
-			logctx.Error(ctx, "ModifyUserOpenOrders unsupported operation", logger.Int("operation", int(operation)))
-			return models.ErrUnsupportedOperation
-		}
-		return nil
-	} else {
-		logctx.Error(ctx, "ModifyUserOpenOrders txid not found", logger.Int("txid", int(txid)))
+	var tx redis.Pipeliner
+	var ok bool
+	if tx, ok = r.txMap[txid]; !ok {
+		logctx.Error(ctx, "TxModifyUserOpenOrders txid not found", logger.Int("txid", int(txid)))
 		return models.ErrNotFound
 	}
+
+	switch operation {
+	case models.Add:
+		userOrdersKey := CreateUserOpenOrdersKey(order.UserId)
+		userOrdersScore := float64(order.Timestamp.UTC().UnixNano())
+		tx.ZAdd(ctx, userOrdersKey, redis.Z{
+			Score:  userOrdersScore,
+			Member: order.Id.String(),
+		})
+		logctx.Debug(ctx, "ModifyUserOpenOrders add", logger.String("orderId", order.Id.String()), logger.String("userId", order.UserId.String()))
+	case models.Remove:
+		userOrdersKey := CreateUserOpenOrdersKey(order.UserId)
+		tx.ZRem(ctx, userOrdersKey, order.Id.String())
+		logctx.Debug(ctx, "ModifyUserOpenOrders remove", logger.String("orderId", order.Id.String()), logger.String("userId", order.UserId.String()))
+	default:
+		logctx.Error(ctx, "ModifyUserOpenOrders unsupported operation", logger.Int("operation", int(operation)))
+		return models.ErrUnsupportedOperation
+	}
+	return nil
 }
 
 // This should be used for all interactions with the `user:<userId>:filledOrders` sorted set (used to store partial-filled and cancelled OR fully filled orders for each user)
 func (r *redisRepository) TxModifyUserFilledOrders(ctx context.Context, txid uint, operation models.Operation, order models.Order) error {
-	if tx, ok := r.txMap[txid]; ok {
-		switch operation {
-		case models.Add:
-			userFilledOrdersKey := CreateUserFilledOrdersKey(order.UserId)
-			userFilledOrdersScore := float64(order.Timestamp.UTC().UnixNano())
-			tx.ZAdd(ctx, userFilledOrdersKey, redis.Z{
-				Score:  userFilledOrdersScore,
-				Member: order.Id.String(),
-			})
-			logctx.Debug(ctx, "ModifyUserFilledOrders add", logger.String("orderId", order.Id.String()), logger.String("userId", order.UserId.String()))
-		case models.Remove:
-			userFilledOrdersKey := CreateUserFilledOrdersKey(order.UserId)
-			tx.ZRem(ctx, userFilledOrdersKey, order.Id.String())
-			logctx.Debug(ctx, "ModifyUserFilledOrders remove", logger.String("orderId", order.Id.String()), logger.String("userId", order.UserId.String()))
-		default:
-			logctx.Error(ctx, "ModifyUserFilledOrders unsupported operation", logger.Int("operation", int(operation)))
-			return models.ErrUnsupportedOperation
-		}
-		return nil
-	} else {
-		logctx.Error(ctx, "ModifyUserFilledOrders txid not found", logger.Int("txid", int(txid)))
+	var tx redis.Pipeliner
+	var ok bool
+	if tx, ok = r.txMap[txid]; !ok {
+		logctx.Error(ctx, "TxModifyUserFilledOrders txid not found", logger.Int("txid", int(txid)))
 		return models.ErrNotFound
 	}
+
+	switch operation {
+	case models.Add:
+		userFilledOrdersKey := CreateUserFilledOrdersKey(order.UserId)
+		userFilledOrdersScore := float64(order.Timestamp.UTC().UnixNano())
+		tx.ZAdd(ctx, userFilledOrdersKey, redis.Z{
+			Score:  userFilledOrdersScore,
+			Member: order.Id.String(),
+		})
+		logctx.Debug(ctx, "ModifyUserFilledOrders add", logger.String("orderId", order.Id.String()), logger.String("userId", order.UserId.String()))
+	case models.Remove:
+		userFilledOrdersKey := CreateUserFilledOrdersKey(order.UserId)
+		tx.ZRem(ctx, userFilledOrdersKey, order.Id.String())
+		logctx.Debug(ctx, "ModifyUserFilledOrders remove", logger.String("orderId", order.Id.String()), logger.String("userId", order.UserId.String()))
+	default:
+		logctx.Error(ctx, "ModifyUserFilledOrders unsupported operation", logger.Int("operation", int(operation)))
+		return models.ErrUnsupportedOperation
+	}
+	return nil
 }
 
 // Removed an unfilled order

--- a/data/redisrepo/tx_order.go
+++ b/data/redisrepo/tx_order.go
@@ -1,0 +1,71 @@
+package redisrepo
+
+import (
+	"context"
+
+	"github.com/google/uuid"
+	"github.com/orbs-network/order-book/models"
+	"github.com/orbs-network/order-book/utils/logger"
+	"github.com/orbs-network/order-book/utils/logger/logctx"
+)
+
+// Generic Building blocks with no biz logic in a single TX
+func (r *redisRepository) TxStart(ctx context.Context) (uint, error) {
+	// --- START TRANSACTION ---
+	tx := r.client.TxPipeline()
+	txid := r.ixIndex + 1
+	r.txMap[txid] = tx
+
+	return txid, nil
+}
+
+func (r *redisRepository) TxEnd(ctx context.Context, txid uint) {
+	if tx, ok := r.txMap[txid]; ok {
+		_, err := tx.Exec(ctx)
+		if err != nil {
+			logctx.Error(ctx, "TxEnd exec failed", logger.Int("txid", int(txid)), logger.Error(err))
+		}
+		return
+	}
+	logctx.Error(ctx, "TxEnd txid not found", logger.Int("txid", int(txid)))
+}
+func (r *redisRepository) TxRemoveOrderFromPrice(ctx context.Context, txid uint, order models.Order) error {
+	if tx, ok := r.txMap[txid]; ok {
+		if order.Side == models.BUY {
+			buyPricesKey := CreateBuySidePricesKey(order.Symbol)
+			tx.ZRem(ctx, buyPricesKey, order.Id.String())
+		} else {
+			sellPricesKey := CreateSellSidePricesKey(order.Symbol)
+			tx.ZRem(ctx, sellPricesKey, order.Id.String())
+		}
+		return nil
+	} else {
+		logctx.Error(ctx, "TxRemoveOrderFromPrice txid not found", logger.Int("txid", int(txid)))
+		return models.ErrNotFound
+	}
+}
+func (r *redisRepository) TxDeleteOrder(ctx context.Context, txid uint, orderId uuid.UUID) error {
+	if tx, ok := r.txMap[txid]; ok {
+		userOrdersKey := CreateUserOpenOrdersKey(orderId)
+		tx.ZRem(ctx, userOrdersKey, orderId)
+		return nil
+	} else {
+		logctx.Error(ctx, "TxDeleteOrder txid not found", logger.Int("txid", int(txid)))
+		return models.ErrNotFound
+	}
+}
+
+// stores only the state of the order
+// as opposed to storeOrderTX - which should be deprecated in the end
+func (r *redisRepository) TxStoreOrder(ctx context.Context, txid uint, order models.Order) error {
+	if tx, ok := r.txMap[txid]; ok {
+		// Store order details by order ID
+		orderIDKey := CreateOrderIDKey(order.Id)
+		orderMap := order.OrderToMap()
+		tx.HSet(ctx, orderIDKey, orderMap)
+		return nil
+	} else {
+		logctx.Error(ctx, "TxStoreOrder txid not found", logger.Int("txid", int(txid)))
+		return models.ErrNotFound
+	}
+}

--- a/data/store/store.go
+++ b/data/store/store.go
@@ -40,13 +40,18 @@ type OrderBookStore interface {
 	GetMarketDepth(ctx context.Context, symbol models.Symbol, depth int) (models.MarketDepth, error)
 	GetOrdersForUser(ctx context.Context, userId uuid.UUID, isFilledOrders bool) (orders []models.Order, totalOrders int, err error)
 	CancelOrdersForUser(ctx context.Context, userId uuid.UUID) ([]uuid.UUID, error)
-	// Generic Building blocks with no biz logic in a single TX
-	TxStart(ctx context.Context) (uint, error)
-	TxEnd(ctx context.Context, txid uint)
-	TxRemoveOrderFromPrice(ctx context.Context, txid uint, order models.Order) error
-	TxDeleteOrder(ctx context.Context, txid uint, orderId uuid.UUID) error
-	TxStoreOrder(ctx context.Context, txid uint, order models.Order) error
+	// ------------------------------
+	// Generic Building blocks with no biz logic in a single
 
+	// PerformTX should be used for all interactions with the Redis repository. Handles the transaction lifecycle.
+	PerformTx(ctx context.Context, action func(txid uint) error) error
+	TxModifyOrder(ctx context.Context, txid uint, operation models.Operation, order models.Order) error
+	TxModifyPrices(ctx context.Context, txid uint, operation models.Operation, order models.Order) error
+	TxModifyClientOId(ctx context.Context, txid uint, operation models.Operation, order models.Order) error
+	TxModifyUserOpenOrders(ctx context.Context, txid uint, operation models.Operation, order models.Order) error
+	TxModifyUserFilledOrders(ctx context.Context, txid uint, operation models.Operation, order models.Order) error
+	TxRemoveUnfilledOrder(ctx context.Context, txid uint, order models.Order) error
+	// ------------------------------
 	// LH side
 	GetMinAsk(ctx context.Context, symbol models.Symbol) models.OrderIter
 	GetMaxBid(ctx context.Context, symbol models.Symbol) models.OrderIter

--- a/data/store/store.go
+++ b/data/store/store.go
@@ -50,7 +50,6 @@ type OrderBookStore interface {
 	TxModifyClientOId(ctx context.Context, txid uint, operation models.Operation, order models.Order) error
 	TxModifyUserOpenOrders(ctx context.Context, txid uint, operation models.Operation, order models.Order) error
 	TxModifyUserFilledOrders(ctx context.Context, txid uint, operation models.Operation, order models.Order) error
-	TxRemoveUnfilledOrder(ctx context.Context, txid uint, order models.Order) error
 	// ------------------------------
 	// LH side
 	GetMinAsk(ctx context.Context, symbol models.Symbol) models.OrderIter

--- a/data/store/store.go
+++ b/data/store/store.go
@@ -40,6 +40,13 @@ type OrderBookStore interface {
 	GetMarketDepth(ctx context.Context, symbol models.Symbol, depth int) (models.MarketDepth, error)
 	GetOrdersForUser(ctx context.Context, userId uuid.UUID, isFilledOrders bool) (orders []models.Order, totalOrders int, err error)
 	CancelOrdersForUser(ctx context.Context, userId uuid.UUID) ([]uuid.UUID, error)
+	// Generic Building blocks with no biz logic in a single TX
+	TxStart(ctx context.Context) (uint, error)
+	TxEnd(ctx context.Context, txid uint)
+	TxRemoveOrderFromPrice(ctx context.Context, txid uint, order models.Order) error
+	TxDeleteOrder(ctx context.Context, txid uint, orderId uuid.UUID) error
+	TxStoreOrder(ctx context.Context, txid uint, order models.Order) error
+
 	// LH side
 	GetMinAsk(ctx context.Context, symbol models.Symbol) models.OrderIter
 	GetMaxBid(ctx context.Context, symbol models.Symbol) models.OrderIter

--- a/e2e/tests/conftest.py
+++ b/e2e/tests/conftest.py
@@ -1,0 +1,60 @@
+import os
+
+import pytest
+from orbs_orderbook import CreateOrderInput, OrderBookSDK, OrderSigner
+from orbs_orderbook.exceptions import ErrApiRequest
+
+BASE_URL = os.environ.get("BASE_URL", "http://localhost")
+PRIVATE_KEY = os.environ.get(
+    "PRIVATE_KEY", "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+)
+API_KEY = os.environ["API_KEY"]
+
+CLIENT_OID = "550e8400-e29b-41d4-a716-446655440000"
+SYMBOL = "MATIC-USDC"
+PRICE = "0.86500000"
+SIZE = "40"
+
+
+@pytest.fixture
+def ob_client():
+    print("HI")
+    yield OrderBookSDK(base_url=BASE_URL, api_key=API_KEY)
+
+
+@pytest.fixture
+def ob_signer(ob_client):
+    yield OrderSigner(
+        private_key=PRIVATE_KEY,
+        sdk=ob_client,
+    )
+
+
+@pytest.fixture(autouse=True, scope="function")
+def cancel_all_orders(ob_client, ob_signer):
+    try:
+        ob_client.cancel_all_orders()
+    except Exception:
+        print("No orders to cancel")
+        pass
+
+
+@pytest.fixture
+def create_new_orders(ob_client, ob_signer, cancel_all_orders):
+    order_input = CreateOrderInput(
+        price=PRICE,
+        size=SIZE,
+        symbol=SYMBOL,
+        side="sell",
+        client_order_id=CLIENT_OID,
+    )
+
+    signature, message = ob_signer.prepare_and_sign_order(order_input)
+
+    yield [
+        ob_client.create_order(
+            order_input=order_input,
+            signature=signature,
+            message=message,
+        )
+    ]

--- a/e2e/tests/maker_endpoints_test.py
+++ b/e2e/tests/maker_endpoints_test.py
@@ -4,70 +4,13 @@ The tests use the Python SDK to interact with the API.
 A local Orderbook instance is required to run the tests.
 """
 
-
-import os
-
 import pytest
-from orbs_orderbook import CreateOrderInput, OrderBookSDK, OrderSigner
+from orbs_orderbook import CreateOrderInput
 from orbs_orderbook.exceptions import ErrApiRequest
-
-BASE_URL = os.environ.get("BASE_URL", "http://localhost")
-PRIVATE_KEY = os.environ.get(
-    "PRIVATE_KEY", "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
-)
-API_KEY = os.environ["API_KEY"]
-
-CLIENT_OID = "550e8400-e29b-41d4-a716-446655440000"
-SYMBOL = "MATIC-USDC"
-PRICE = "0.86500000"
-SIZE = "40"
-
+from conftest import CLIENT_OID, SIZE, SYMBOL, API_KEY
 
 # TODO 1: Add test for get market depth
 # TODO 2: Add different test scenaries (eg. different failed states)
-
-
-@pytest.fixture
-def ob_client():
-    yield OrderBookSDK(base_url=BASE_URL, api_key=API_KEY)
-
-
-@pytest.fixture
-def ob_signer(ob_client):
-    yield OrderSigner(
-        private_key=PRIVATE_KEY,
-        sdk=ob_client,
-    )
-
-
-@pytest.fixture(autouse=True, scope="function")
-def cancel_all_orders(ob_client, ob_signer):
-    try:
-        ob_client.cancel_all_orders()
-    except Exception:
-        print("No orders to cancel")
-        pass
-
-
-@pytest.fixture
-def create_new_orders(ob_client, ob_signer, cancel_all_orders):
-    order_input = CreateOrderInput(
-        price=PRICE,
-        size=SIZE,
-        symbol=SYMBOL,
-        side="sell",
-        client_order_id=CLIENT_OID,
-    )
-
-    signature, message = ob_signer.prepare_and_sign_order(order_input)
-
-    yield [
-        ob_client.create_order(
-            order_input=order_input,
-            signature=signature,
-            message=message,
-        )
-    ]
 
 
 def test_create_order_success(ob_client, ob_signer):

--- a/e2e/tests/requirements.txt
+++ b/e2e/tests/requirements.txt
@@ -1,2 +1,3 @@
-orbs-orderbook-sdk==0.9.1
+orbs-orderbook-sdk==0.9.2
 pytest==7.4.4
+redis==5.0.3

--- a/mocks/service.go
+++ b/mocks/service.go
@@ -127,10 +127,6 @@ func (m *MockOrderBookStore) TxModifyUserFilledOrders(ctx context.Context, txid 
 	return m.Error
 }
 
-func (m *MockOrderBookStore) TxRemoveUnfilledOrder(ctx context.Context, txid uint, order models.Order) error {
-	return m.Error
-}
-
 func (m *MockOrderBookStore) GetUserByPublicKey(ctx context.Context, publicKey string) (*models.User, error) {
 	if m.Error != nil {
 		return nil, m.Error

--- a/mocks/service.go
+++ b/mocks/service.go
@@ -103,19 +103,31 @@ func (m *MockOrderBookStore) CancelOrdersForUser(ctx context.Context, userId uui
 }
 
 // Generic Building blocks with no biz logic in a single TX
-func (m *MockOrderBookStore) TxStart(ctx context.Context) (uint, error) {
-	return 0, m.Error
+func (m *MockOrderBookStore) PerformTx(ctx context.Context, action func(txid uint) error) error {
+	return m.Error
 }
-func (m *MockOrderBookStore) TxEnd(ctx context.Context, txid uint) {
 
-}
-func (m *MockOrderBookStore) TxRemoveOrderFromPrice(ctx context.Context, txid uint, order models.Order) error {
+func (m *MockOrderBookStore) TxModifyOrder(ctx context.Context, txid uint, operation models.Operation, order models.Order) error {
 	return m.Error
 }
-func (m *MockOrderBookStore) TxDeleteOrder(ctx context.Context, txid uint, orderId uuid.UUID) error {
+
+func (m *MockOrderBookStore) TxModifyPrices(ctx context.Context, txid uint, operation models.Operation, order models.Order) error {
 	return m.Error
 }
-func (m *MockOrderBookStore) TxStoreOrder(ctx context.Context, txid uint, order models.Order) error {
+
+func (m *MockOrderBookStore) TxModifyClientOId(ctx context.Context, txid uint, operation models.Operation, order models.Order) error {
+	return m.Error
+}
+
+func (m *MockOrderBookStore) TxModifyUserOpenOrders(ctx context.Context, txid uint, operation models.Operation, order models.Order) error {
+	return m.Error
+}
+
+func (m *MockOrderBookStore) TxModifyUserFilledOrders(ctx context.Context, txid uint, operation models.Operation, order models.Order) error {
+	return m.Error
+}
+
+func (m *MockOrderBookStore) TxRemoveUnfilledOrder(ctx context.Context, txid uint, order models.Order) error {
 	return m.Error
 }
 

--- a/mocks/service.go
+++ b/mocks/service.go
@@ -102,6 +102,23 @@ func (m *MockOrderBookStore) CancelOrdersForUser(ctx context.Context, userId uui
 	return orderIds, m.Error
 }
 
+// Generic Building blocks with no biz logic in a single TX
+func (m *MockOrderBookStore) TxStart(ctx context.Context) (uint, error) {
+	return 0, m.Error
+}
+func (m *MockOrderBookStore) TxEnd(ctx context.Context, txid uint) {
+
+}
+func (m *MockOrderBookStore) TxRemoveOrderFromPrice(ctx context.Context, txid uint, order models.Order) error {
+	return m.Error
+}
+func (m *MockOrderBookStore) TxDeleteOrder(ctx context.Context, txid uint, orderId uuid.UUID) error {
+	return m.Error
+}
+func (m *MockOrderBookStore) TxStoreOrder(ctx context.Context, txid uint, order models.Order) error {
+	return m.Error
+}
+
 func (m *MockOrderBookStore) GetUserByPublicKey(ctx context.Context, publicKey string) (*models.User, error) {
 	if m.Error != nil {
 		return nil, m.Error

--- a/mocks/transport.go
+++ b/mocks/transport.go
@@ -29,7 +29,7 @@ func (m *MockOrderBookService) CreateOrder(ctx context.Context, input service.Cr
 	return *m.Order, m.Error
 }
 
-func (m *MockOrderBookService) CancelOrder(ctx context.Context, input service.CancelOrderInput) (cancelledOrderId *uuid.UUID, err error) {
+func (m *MockOrderBookService) CancelOrder(ctx context.Context, input service.CancelOrderInput) (*uuid.UUID, error) {
 	if m.Error != nil {
 		return nil, m.Error
 	}

--- a/models/crud.go
+++ b/models/crud.go
@@ -1,0 +1,9 @@
+package models
+
+type Operation int
+
+const (
+	Add Operation = iota
+	Remove
+	Update
+)

--- a/models/errors.go
+++ b/models/errors.go
@@ -3,6 +3,7 @@ package models
 import "errors"
 
 var ErrNotFound = errors.New("entity not found")
+var ErrUnsupportedOperation = errors.New("unsupported operation")
 var ErrClashingOrderId = errors.New("order already exists")
 var ErrClashingClientOrderId = errors.New("order already exists")
 var ErrUnexpectedError = errors.New("unexpected error")

--- a/models/order.go
+++ b/models/order.go
@@ -219,7 +219,7 @@ func (o *Order) IsFilled() bool {
 }
 
 func (o *Order) IsUnfilled() bool {
-	return o.SizeFilled.IsZero() && o.SizePending.IsZero()
+	return o.SizeFilled.IsZero()
 }
 
 func (o *Order) IsPartialFilled() bool {

--- a/models/order_test.go
+++ b/models/order_test.go
@@ -350,32 +350,14 @@ func TestOrder_IsUnfilled(t *testing.T) {
 		{
 			name: "sizeFilled 0, sizePending 0",
 			order: Order{
-				SizeFilled:  decimal.Zero,
-				SizePending: decimal.Zero,
+				SizeFilled: decimal.Zero,
 			},
 			expected: true,
 		},
 		{
 			name: "sizeFilled 1000, sizePending 0",
 			order: Order{
-				SizeFilled:  decimal.NewFromInt(1000),
-				SizePending: decimal.Zero,
-			},
-			expected: false,
-		},
-		{
-			name: "sizeFilled 0, sizePending 1000",
-			order: Order{
-				SizeFilled:  decimal.Zero,
-				SizePending: decimal.NewFromInt(1000),
-			},
-			expected: false,
-		},
-		{
-			name: "sizeFilled 1000, sizePending 1000",
-			order: Order{
-				SizeFilled:  decimal.NewFromInt(1000),
-				SizePending: decimal.NewFromInt(1000),
+				SizeFilled: decimal.NewFromInt(1000),
 			},
 			expected: false,
 		},

--- a/service/cancel_order.go
+++ b/service/cancel_order.go
@@ -93,6 +93,9 @@ func (s *Service) CancelOrder(ctx context.Context, input CancelOrderInput) (*uui
 				logctx.Error(ctx, "Failed updating order", logger.String("id", input.Id.String()), logger.Error(err))
 				return fmt.Errorf("failed updating order: %w", err)
 			}
+		default:
+			logctx.Error(ctx, "unexpected order state", logger.String("orderId", order.Id.String()), logger.String("size", order.Size.String()), logger.String("sizeFilled", order.SizeFilled.String()), logger.String("sizePending", order.SizePending.String()))
+			return models.ErrUnexpectedError
 		}
 
 		return nil

--- a/service/cancel_order.go
+++ b/service/cancel_order.go
@@ -15,8 +15,53 @@ type CancelOrderInput struct {
 	UserId      uuid.UUID
 }
 
+//flow chart
+//https://miro.com/welcomeonboard/Umt0YnpDN3BEcUh1U0JZaHNpejJNUHV3QmpBTGpTNFdybXVlemk2QlV4RHAwc2xVSXR5VzM0NzJwUlhGZEFRMnwzMDc0NDU3MzU4MzEyODA0NjQ2fDI=?share_link_id=23847173917
+
+func (s *Service) CancelOrder(ctx context.Context, input CancelOrderInput) (*uuid.UUID, error) {
+	// get order
+	order, err := s.getOrder(ctx, input.IsClientOId, input.Id)
+	if err != nil {
+		logctx.Warn(ctx, "order not found", logger.String("id", input.Id.String()), logger.Bool("isClientOId", input.IsClientOId))
+		return nil, err
+	}
+	// remove from price
+	txid, err := s.orderBookStore.TxStart(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer s.orderBookStore.TxEnd(ctx, txid)
+
+	err = s.orderBookStore.TxRemoveOrderFromPrice(ctx, txid, *order)
+	if err != nil {
+		logctx.Error(ctx, "TxRemoveOrderFromPrice", logger.String("id", input.Id.String()), logger.Bool("isClientOId", input.IsClientOId))
+		return nil, err
+	}
+	// mark as cancelled
+	order.Cancelled = true
+	// isUnfilled?
+	if order.IsUnfilled() {
+		// non Pending?
+		if !order.IsPending() {
+			err := s.orderBookStore.TxDeleteOrder(ctx, txid, order.Id)
+			if err != nil {
+				logctx.Error(ctx, "DeleteOrder error  in Cancel Unfilled non pending Order", logger.String("orderId", input.Id.String()), logger.Error(err))
+				return nil, err
+			}
+			return &order.Id, nil
+		}
+	}
+	// store cancelled state change
+	err = s.orderBookStore.TxStoreOrder(ctx, txid, *order)
+	if err != nil {
+		logctx.Error(ctx, "StoreOpenOrder error  in cancel of filled or pending order", logger.String("orderId", input.Id.String()), logger.Error(err))
+		return nil, err
+	}
+	return &order.Id, nil
+}
+
 // CancelOrder cancels an order by its ID or clientOId. If `isClientOId` is true, the `id` is treated as a clientOinput.Id, otherwise it is treated as an orderId.
-func (s *Service) CancelOrder(ctx context.Context, input CancelOrderInput) (cancelledOrderId *uuid.UUID, err error) {
+func (s *Service) CancelOrderOld(ctx context.Context, input CancelOrderInput) (*uuid.UUID, error) {
 
 	order, err := s.getOrder(ctx, input.IsClientOId, input.Id)
 	if err != nil {

--- a/service/cancel_order.go
+++ b/service/cancel_order.go
@@ -36,6 +36,11 @@ func (s *Service) CancelOrder(ctx context.Context, input CancelOrderInput) (*uui
 		return nil, models.ErrOrderCancelled
 	}
 
+	if order.IsFilled() {
+		logctx.Warn(ctx, "order already filled", logger.String("orderId", order.Id.String()))
+		return nil, models.ErrOrderFilled
+	}
+
 	err = s.orderBookStore.PerformTx(ctx, func(txid uint) error {
 		order.Cancelled = true
 

--- a/service/cancel_order_test.go
+++ b/service/cancel_order_test.go
@@ -32,9 +32,9 @@ func TestService_CancelOrder(t *testing.T) {
 	}{
 		{name: "unexpected error when finding order by orderId - returns error", isClientOId: false, err: assert.AnError, expectedOrderId: nil, expectedErr: assert.AnError},
 		{name: "unexpected error when finding order by clientOId - returns error", isClientOId: true, err: assert.AnError, expectedOrderId: nil, expectedErr: assert.AnError},
-		{name: "order not found - returns `ErrNotFound` error", isClientOId: false, order: nil, err: nil, expectedOrderId: nil, expectedErr: models.ErrNotFound},
-		{name: "cancelling order not possible when order is pending", isClientOId: false, order: &models.Order{UserId: userId, Size: decimal.NewFromInt(9999999), SizePending: decimal.NewFromFloat(254), SizeFilled: decimal.NewFromFloat(32323.32)}, expectedOrderId: nil, expectedErr: models.ErrOrderPending},
-		{name: "cancelling order not possible when order is filled", isClientOId: false, order: &models.Order{UserId: userId, SizePending: decimal.NewFromFloat(0), SizeFilled: decimal.NewFromFloat(99999.99), Size: decimal.NewFromFloat(99999.99)}, expectedOrderId: nil, expectedErr: models.ErrOrderFilled},
+		//{name: "order not found - returns `ErrNotFound` error", isClientOId: false, order: nil, err: nil, expectedOrderId: nil, expectedErr: models.ErrNotFound},
+		// {name: "cancelling order is possible when order is pending", isClientOId: false, order: &models.Order{UserId: userId, Size: decimal.NewFromInt(9999999), SizePending: decimal.NewFromFloat(254), SizeFilled: decimal.NewFromFloat(32323.32)}, expectedOrderId: uuid.Zero(), expectedErr: nil},
+		// {name: "cancelling order not possible when order is filled", isClientOId: false, order: &models.Order{UserId: userId, SizePending: decimal.NewFromFloat(0), SizeFilled: decimal.NewFromFloat(99999.99), Size: decimal.NewFromFloat(99999.99)}, expectedOrderId: nil, expectedErr: models.ErrOrderFilled},
 		{name: "unexpected error when removing order - returns error", isClientOId: false, order: order, err: assert.AnError, expectedOrderId: nil, expectedErr: assert.AnError},
 		{name: "order removed successfully by orderId - returns cancelled orderId", isClientOId: false, order: order, err: nil, expectedOrderId: &orderId, expectedErr: nil},
 		{name: "order removed successfully by clientOId - returns cancelled orderId", isClientOId: true, order: order, err: nil, expectedOrderId: &orderId, expectedErr: nil},

--- a/service/cancel_order_test.go
+++ b/service/cancel_order_test.go
@@ -32,12 +32,13 @@ func TestService_CancelOrder(t *testing.T) {
 	}{
 		{name: "unexpected error when finding order by orderId - returns error", isClientOId: false, err: assert.AnError, expectedOrderId: nil, expectedErr: assert.AnError},
 		{name: "unexpected error when finding order by clientOId - returns error", isClientOId: true, err: assert.AnError, expectedOrderId: nil, expectedErr: assert.AnError},
-		//{name: "order not found - returns `ErrNotFound` error", isClientOId: false, order: nil, err: nil, expectedOrderId: nil, expectedErr: models.ErrNotFound},
-		// {name: "cancelling order is possible when order is pending", isClientOId: false, order: &models.Order{UserId: userId, Size: decimal.NewFromInt(9999999), SizePending: decimal.NewFromFloat(254), SizeFilled: decimal.NewFromFloat(32323.32)}, expectedOrderId: uuid.Zero(), expectedErr: nil},
-		// {name: "cancelling order not possible when order is filled", isClientOId: false, order: &models.Order{UserId: userId, SizePending: decimal.NewFromFloat(0), SizeFilled: decimal.NewFromFloat(99999.99), Size: decimal.NewFromFloat(99999.99)}, expectedOrderId: nil, expectedErr: models.ErrOrderFilled},
-		{name: "unexpected error when removing order - returns error", isClientOId: false, order: order, err: assert.AnError, expectedOrderId: nil, expectedErr: assert.AnError},
-		{name: "order removed successfully by orderId - returns cancelled orderId", isClientOId: false, order: order, err: nil, expectedOrderId: &orderId, expectedErr: nil},
-		{name: "order removed successfully by clientOId - returns cancelled orderId", isClientOId: true, order: order, err: nil, expectedOrderId: &orderId, expectedErr: nil},
+		{name: "order not found - returns `ErrNotFound` error", isClientOId: false, order: nil, err: nil, expectedOrderId: nil, expectedErr: models.ErrNotFound},
+		{name: "order already cancelled - returns `ErrOrderCancelled` error", isClientOId: false, order: &models.Order{Cancelled: true}, expectedOrderId: nil, expectedErr: models.ErrOrderCancelled},
+		{name: "order already filled so cannot be cancelled - returns `ErrOrderFilled`", isClientOId: false, order: &models.Order{UserId: userId, SizeFilled: decimal.NewFromFloat(99999.99), Size: decimal.NewFromFloat(99999.99)}, expectedOrderId: nil, expectedErr: models.ErrOrderFilled},
+		{name: "order is partially filled and not pending", isClientOId: false, order: &models.Order{Id: order.Id, UserId: userId, SizeFilled: decimal.NewFromFloat(10), Size: decimal.NewFromFloat(50), SizePending: decimal.NewFromFloat(0)}, expectedOrderId: &order.Id, expectedErr: nil},
+		{name: "order is partially filled and pending", isClientOId: false, order: &models.Order{Id: order.Id, UserId: userId, SizeFilled: decimal.NewFromFloat(10), Size: decimal.NewFromFloat(50), SizePending: decimal.NewFromFloat(40)}, expectedOrderId: &order.Id, expectedErr: nil},
+		{name: "order is not filled and not pending", isClientOId: false, order: &models.Order{Id: order.Id, UserId: userId, SizeFilled: decimal.NewFromFloat(0), Size: decimal.NewFromFloat(50), SizePending: decimal.NewFromFloat(0)}, expectedOrderId: &order.Id, expectedErr: nil},
+		{name: "order is not filled and pending", isClientOId: false, order: &models.Order{Id: order.Id, UserId: userId, SizeFilled: decimal.NewFromFloat(0), Size: decimal.NewFromFloat(50), SizePending: decimal.NewFromFloat(40)}, expectedOrderId: &order.Id, expectedErr: nil},
 	}
 
 	for _, c := range testCases {

--- a/service/service.go
+++ b/service/service.go
@@ -14,7 +14,7 @@ import (
 
 type OrderBookService interface {
 	CreateOrder(ctx context.Context, input CreateOrderInput) (models.Order, error)
-	CancelOrder(ctx context.Context, input CancelOrderInput) (cancelledOrderId *uuid.UUID, err error)
+	CancelOrder(ctx context.Context, input CancelOrderInput) (*uuid.UUID, error)
 	GetOrderById(ctx context.Context, orderId uuid.UUID) (*models.Order, error)
 	GetOrderByClientOId(ctx context.Context, clientOId uuid.UUID) (*models.Order, error)
 	GetMarketDepth(ctx context.Context, symbol models.Symbol, depth int) (models.MarketDepth, error)

--- a/transport/rest/cancel_order.go
+++ b/transport/rest/cancel_order.go
@@ -106,6 +106,12 @@ func (h *Handler) handleCancelOrder(input hInput) {
 		return
 	}
 
+	if err == models.ErrOrderCancelled {
+		logctx.Warn(input.ctx, "order already cancelled", logger.String("id", input.id.String()))
+		restutils.WriteJSONError(input.ctx, input.w, http.StatusConflict, "Order already cancelled")
+		return
+	}
+
 	if err == models.ErrOrderPending {
 		logctx.Warn(input.ctx, "order is cancelled but part of it is pending (locked)", logger.String("id", input.id.String()))
 		restutils.WriteJSONError(input.ctx, input.w, http.StatusConflict, "order is cancelled but some of it's size is pending")

--- a/transport/rest/cancel_order_test.go
+++ b/transport/rest/cancel_order_test.go
@@ -76,6 +76,7 @@ func TestHandler_CancelOrderByOrderId(t *testing.T) {
 			http.StatusNotFound,
 			"{\"status\":404,\"msg\":\"Order not found\"}\n",
 		},
+		{"order already cancelled", &mocks.MockOrderBookService{Error: models.ErrOrderCancelled}, fmt.Sprintf("/order/%s", orderId.String()), http.StatusConflict, "{\"status\":409,\"msg\":\"Order already cancelled\"}\n"},
 		{
 			"unexpected error from service",
 			&mocks.MockOrderBookService{Error: assert.AnError},

--- a/transport/rest/taker.go
+++ b/transport/rest/taker.go
@@ -163,7 +163,11 @@ func (h *Handler) handleQuote(w http.ResponseWriter, r *http.Request, isSwap boo
 	side := pair.GetSide(req.InToken)
 	svcQuoteRes, err := h.svc.GetQuote(r.Context(), pair.Symbol(), side, inAmount, minOutAmount)
 	if err != nil {
-		restutils.WriteJSONError(ctx, w, http.StatusInternalServerError, err.Error())
+		if err == models.ErrMinOutAmount {
+			restutils.WriteJSONError(ctx, w, http.StatusBadRequest, err.Error())
+		} else {
+			restutils.WriteJSONError(ctx, w, http.StatusInternalServerError, err.Error())
+		}
 		return nil
 	}
 


### PR DESCRIPTION
1. Expose generic way to do transactions in the service layer
2. Add generic modify methods to repo to support modifying different Redis keys
3. Refactor cancel order method