### PR TITLE
Fix create orders partial failure response

### DIFF
--- a/e2e/maker/requirements.txt
+++ b/e2e/maker/requirements.txt
@@ -1,2 +1,2 @@
-orbs-orderbook-sdk==0.9.1
+orbs-orderbook-sdk==0.10.1
 requests==2.31.0

--- a/e2e/tests/conftest.py
+++ b/e2e/tests/conftest.py
@@ -18,7 +18,6 @@ SIZE = "40"
 
 @pytest.fixture
 def ob_client():
-    print("HI")
     yield OrderBookSDK(base_url=BASE_URL, api_key=API_KEY)
 
 

--- a/e2e/tests/requirements.txt
+++ b/e2e/tests/requirements.txt
@@ -1,3 +1,3 @@
-orbs-orderbook-sdk==0.9.2
+orbs-orderbook-sdk==0.10.1
 pytest==7.4.4
 redis==5.0.3

--- a/transport/rest/create_orders.go
+++ b/transport/rest/create_orders.go
@@ -154,7 +154,7 @@ func (h *Handler) CreateOrders(w http.ResponseWriter, r *http.Request) {
 
 	if len(createdOrders) != len(args.Orders) {
 		logctx.Warn(ctx, "not all orders were created", logger.String("userId", user.Id.String()), logger.Int("numOfOrders", len(createdOrders)), logger.Int("numOfOrdersRequested", len(args.Orders)))
-		restutils.WriteJSONResponse(ctx, w, http.StatusBadRequest, response, logger.String("userId", user.Id.String()))
+		restutils.WriteJSONResponse(ctx, w, http.StatusMultiStatus, response, logger.String("userId", user.Id.String()))
 		return
 	}
 


### PR DESCRIPTION
1. Fix create orders partial failure response (in case that one order was created and another failed, return details about the created order and what went wrong with the other)
2. Update e2e tests