### PR TITLE
Refactor user order subscription websockets to reuse active Redis connections

### DIFF
--- a/cmd/order-book/main.go
+++ b/cmd/order-book/main.go
@@ -72,6 +72,7 @@ func setup() {
 	}
 
 	rdb := redis.NewClient(opt)
+	defer rdb.Close()
 
 	repository, err := redisrepo.NewRedisRepository(rdb)
 	if err != nil {

--- a/data/redisrepo/pub_sub.go
+++ b/data/redisrepo/pub_sub.go
@@ -3,12 +3,16 @@ package redisrepo
 import (
 	"context"
 	"fmt"
+	"os"
+	"strconv"
 
 	"github.com/orbs-network/order-book/utils/logger"
 	"github.com/orbs-network/order-book/utils/logger/logctx"
 )
 
-// PublishEvent publishes an event to Redis
+var BUFFER_SIZE = os.Getenv("REDIS_BUFFER_SIZE")
+
+// PublishEvent publishes an event to a Redis channel
 func (r *redisRepository) PublishEvent(ctx context.Context, key string, value interface{}) error {
 	err := r.client.Publish(ctx, key, value).Err()
 
@@ -19,33 +23,102 @@ func (r *redisRepository) PublishEvent(ctx context.Context, key string, value in
 	return nil
 }
 
-// SubscribeToEvents subscribes to events on a given Redis channel
 func (r *redisRepository) SubscribeToEvents(ctx context.Context, channel string) (chan []byte, error) {
-	logctx.Debug(ctx, "subscribing to channel", logger.String("channel", channel))
+	r.mu.Lock()
+	defer r.mu.Unlock()
 
-	// Subscribe to the specified channel
-	pubsub := r.client.Subscribe(ctx, channel)
+	sub, exists := r.subscriptions[channel]
+	if !exists {
+		pubsub := r.client.Subscribe(ctx, channel)
+		_, err := pubsub.Receive(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("error subscribing to channel: %w", err)
+		}
 
-	// Wait for confirmation that subscription is created
-	_, err := pubsub.Receive(ctx)
-	if err != nil {
-		logctx.Error(ctx, "error on receiving from pubsub", logger.Error(err), logger.String("channel", channel))
-		return nil, fmt.Errorf("error on receiving from pubsub: %w", err)
+		sub = &channelSubscription{
+			pubsub:   pubsub,
+			clients:  make(map[chan []byte]struct{}),
+			messages: make(chan []byte, getBufferSize()),
+		}
+		r.subscriptions[channel] = sub
+
+		// Start a goroutine to distribute messages to clients
+		go r.distributeMessages(ctx, channel, sub)
 	}
 
-	// Create a channel to pass messages to the caller
-	messages := make(chan []byte)
+	// Create a new client channel and add it to the subscription's clients
+	clientChan := make(chan []byte, getBufferSize())
+	sub.clients[clientChan] = struct{}{}
 
-	// Listen for messages
-	go func() {
-		defer pubsub.Close()
-		ch := pubsub.Channel()
-		for msg := range ch {
-			messages <- []byte(msg.Payload)
+	return clientChan, nil
+}
+
+// UnsubscribeFromEvents unsubscribes a client from a Redis channel
+func (r *redisRepository) UnsubscribeFromEvents(ctx context.Context, channel string, clientChan chan []byte) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	sub, exists := r.subscriptions[channel]
+	if !exists {
+		return
+	}
+
+	delete(sub.clients, clientChan)
+	close(clientChan)
+
+	if len(sub.clients) == 0 {
+		if err := sub.pubsub.Close(); err != nil {
+			logctx.Error(ctx, "error closing pubsub", logger.Error(err), logger.String("channel", channel))
 		}
-		logctx.Debug(ctx, "subscription ended", logger.String("channel", channel))
-		close(messages)
+		delete(r.subscriptions, channel)
+	}
+}
+
+// distributeMessages listens for messages on a Redis channel and sends them to all subscribed clients
+func (r *redisRepository) distributeMessages(ctx context.Context, channel string, sub *channelSubscription) {
+	defer func() {
+		sub.pubsub.Close()
+		close(sub.messages)
+		r.mu.Lock()
+		delete(r.subscriptions, channel)
+		r.mu.Unlock()
 	}()
 
-	return messages, nil
+	for {
+		select {
+		case msg := <-sub.pubsub.Channel():
+			// Send the message to all subscribed clients
+			r.mu.Lock()
+
+			if len(sub.clients) == 0 {
+				logctx.Debug(ctx, "no active subscribers, dropping message", logger.String("channel", channel))
+				r.mu.Unlock()
+				continue
+			}
+
+			for clientChan := range sub.clients {
+				select {
+				case clientChan <- []byte(msg.Payload):
+				default:
+					logctx.Error(ctx, "client channel is full, dropping message", logger.String("channel", channel), logger.Int("buffer_size", getBufferSize()), logger.Int("clients", len(sub.clients)), logger.Int("buffered_messages", len(sub.messages)))
+				}
+			}
+			r.mu.Unlock()
+		case <-ctx.Done():
+			logctx.Debug(ctx, "context cancelled", logger.String("channel", channel))
+			return
+		}
+	}
+}
+
+// getBufferSize returns the configurable buffer size for the channelSubscription messages channel
+func getBufferSize() int {
+	if BUFFER_SIZE == "" {
+		return 100
+	}
+	bufferSize, err := strconv.Atoi(BUFFER_SIZE)
+	if err != nil {
+		return 100
+	}
+	return bufferSize
 }

--- a/data/redisrepo/repository.go
+++ b/data/redisrepo/repository.go
@@ -2,15 +2,24 @@ package redisrepo
 
 import (
 	"fmt"
+	"sync"
 
 	"github.com/redis/go-redis/v9"
 )
 
 type redisRepository struct {
-	cmdable redis.Cmdable
-	client  *redis.Client
-	txMap   map[uint]redis.Pipeliner
-	ixIndex uint
+	cmdable       redis.Cmdable
+	client        *redis.Client
+	txMap         map[uint]redis.Pipeliner
+	ixIndex       uint
+	subscriptions map[string]*channelSubscription
+	mu            sync.Mutex
+}
+
+type channelSubscription struct {
+	pubsub   *redis.PubSub
+	clients  map[chan []byte]struct{}
+	messages chan []byte
 }
 
 func NewRedisRepository(cmdable redis.Cmdable) (*redisRepository, error) {
@@ -25,8 +34,9 @@ func NewRedisRepository(cmdable redis.Cmdable) (*redisRepository, error) {
 
 	txMap := make(map[uint]redis.Pipeliner)
 	return &redisRepository{
-		cmdable: cmdable,
-		client:  client,
-		txMap:   txMap,
+		cmdable:       cmdable,
+		client:        client,
+		txMap:         txMap,
+		subscriptions: make(map[string]*channelSubscription),
 	}, nil
 }

--- a/data/store/store.go
+++ b/data/store/store.go
@@ -65,4 +65,5 @@ type OrderBookStore interface {
 	// PubSub
 	PublishEvent(ctx context.Context, key string, value interface{}) error
 	SubscribeToEvents(ctx context.Context, channel string) (chan []byte, error)
+	UnsubscribeFromEvents(ctx context.Context, channel string, clientChan chan []byte)
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,14 @@
-version: "3.8"
 services:
   server:
+    deploy:
+      resources:
+      # CPU and memory limits similar to the production setup
+        limits:
+          cpus: '2.0'
+          memory: 1g
+        reservations:
+          cpus: '2.0'
+          memory: 1g
     build:
       dockerfile: cmd/order-book.Dockerfile
       context: .
@@ -14,6 +22,7 @@ services:
       - PORT=8080
       - RPC_URL=${RPC_URL}
       - LOG_LEVEL=debug
+      - REPORT_SEC_INTERVAL=999999999999
     depends_on:
       - db
     develop:
@@ -30,7 +39,8 @@ services:
     restart: always
     ports:
       - "6379:6379"
-    command: redis-server --save 60 1 --loglevel warning
+      # Max clients and memory limit similar to the production setup
+    command: redis-server --save 60 1 --loglevel warning --maxclients 512 --maxmemory 512mb
     volumes:
       - db:/data
 

--- a/mocks/service.go
+++ b/mocks/service.go
@@ -193,6 +193,9 @@ func (m *MockOrderBookStore) SubscribeToEvents(ctx context.Context, channel stri
 	return m.EventsChan, m.Error
 }
 
+func (m *MockOrderBookStore) UnsubscribeFromEvents(ctx context.Context, channel string, clientChan chan []byte) {
+}
+
 func (r *MockOrderBookStore) ReadStrKey(ctx context.Context, key string) (string, error) {
 	return "", nil
 }

--- a/mocks/transport.go
+++ b/mocks/transport.go
@@ -79,6 +79,10 @@ func (m *MockOrderBookService) SubscribeUserOrders(ctx context.Context, userId u
 	return m.OrderEvents, m.Error
 }
 
+func (m *MockOrderBookService) UnsubscribeUserOrders(ctx context.Context, userId uuid.UUID, clientChan chan []byte) error {
+	return m.Error
+}
+
 func (m *MockOrderBookService) GetQuote(ctx context.Context, symbol models.Symbol, makerSide models.Side, inAmount decimal.Decimal, minOutAmount *decimal.Decimal, makerInToken string) (models.QuoteRes, error) {
 	return m.QuoteRes, m.Error
 }

--- a/scripts/ws-test/multi-ws.py
+++ b/scripts/ws-test/multi-ws.py
@@ -1,0 +1,45 @@
+import asyncio
+import websockets
+import os
+
+
+async def connect_and_listen(client_id):
+    url = "ws://127.0.0.1/api/v1/ws/orders"
+    api_key = os.getenv("API_KEY")
+
+    if api_key is None:
+        print("Error: API_KEY environment variable not set.")
+        return
+
+    headers = {"X-API-KEY": f"Bearer {api_key}"}
+
+    while True:
+        try:
+            async with websockets.connect(url, extra_headers=headers, ping_interval=None) as websocket:
+                print(f"Client {client_id} connected to server")
+                while True:
+                    try:
+                        message = await websocket.recv()
+                        # print(f"Client {client_id} received message: {message}")
+                        print(f"Client {client_id} received message")
+                    except websockets.exceptions.ConnectionClosedError as e:
+                        print(f"Client {client_id} connection closed with error: {e}")
+                        break
+        except (websockets.exceptions.ConnectionClosedError, websockets.exceptions.ConnectionClosed) as e:
+            print(f"Client {client_id} failed to connect or connection lost: {e}")
+        except Exception as e:
+            print(f"Client {client_id} unexpected error: {e}")
+
+        print(f"Client {client_id} reconnecting in 5 seconds...")
+        await asyncio.sleep(5)  # Wait before attempting to reconnect
+
+
+async def main(num_clients):
+    # Create multiple WebSocket connections
+    tasks = [asyncio.create_task(connect_and_listen(client_id)) for client_id in range(num_clients)]
+    await asyncio.gather(*tasks)
+
+
+if __name__ == "__main__":
+    num_clients = 5  # Set the number of WebSocket connections to create
+    asyncio.get_event_loop().run_until_complete(main(num_clients))

--- a/scripts/ws-test/requirements.txt
+++ b/scripts/ws-test/requirements.txt
@@ -1,0 +1,2 @@
+asyncio==3.4.3
+websockets==12.0

--- a/service/service.go
+++ b/service/service.go
@@ -25,6 +25,7 @@ type OrderBookService interface {
 	GetSwapFills(ctx context.Context, userId uuid.UUID, symbol models.Symbol, startAt, endAt time.Time) ([]models.Fill, error)
 	// Subscribe to order updates for a specific user
 	SubscribeUserOrders(ctx context.Context, userId uuid.UUID) (chan []byte, error)
+	UnsubscribeUserOrders(ctx context.Context, userId uuid.UUID, clientChan chan []byte) error
 
 	// taker api - INSTEAD
 	GetQuote(ctx context.Context, symbol models.Symbol, makerSide models.Side, inAmount decimal.Decimal, minOutAmount *decimal.Decimal, makerInToken string) (models.QuoteRes, error)

--- a/transport/websocket/user_order_handler.go
+++ b/transport/websocket/user_order_handler.go
@@ -2,6 +2,7 @@ package websocket
 
 import (
 	"net/http"
+	"time"
 
 	"github.com/gorilla/websocket"
 	"github.com/orbs-network/order-book/service"
@@ -14,18 +15,19 @@ import (
 // The user is authenticated using the API key in the request
 func WebSocketOrderHandler(orderSvc service.OrderBookService, getUserByApiKey middleware.GetUserByApiKeyFunc) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
 		// Extract API key from query parameters
 		apiKey, err := middleware.BearerToken(r, "X-API-KEY")
 		if err != nil {
-			logctx.Warn(r.Context(), "incorrect API key format", logger.Error(err))
+			logctx.Warn(ctx, "incorrect API key format", logger.Error(err))
 			http.Error(w, "Invalid API key (ensure the format is 'Bearer YOUR-API-KEY')", http.StatusBadRequest)
 			return
 		}
 
 		// Authenticate user
-		user, err := getUserByApiKey(r.Context(), apiKey)
+		user, err := getUserByApiKey(ctx, apiKey)
 		if err != nil {
-			logctx.Warn(r.Context(), "user not found by api key")
+			logctx.Warn(ctx, "user not found by api key")
 			http.Error(w, "Unauthorized", http.StatusUnauthorized)
 			return
 		}
@@ -34,27 +36,53 @@ func WebSocketOrderHandler(orderSvc service.OrderBookService, getUserByApiKey mi
 		upgrader := websocket.Upgrader{}
 		conn, err := upgrader.Upgrade(w, r, nil)
 		if err != nil {
-			logctx.Error(r.Context(), "error upgrading to websocket", logger.Error(err))
+			logctx.Error(ctx, "error upgrading to websocket", logger.Error(err), logger.String("userId", user.Id.String()))
 			http.Error(w, "Error subscribing to orders", http.StatusInternalServerError)
 			return
 		}
 		defer conn.Close()
 
-		// Subscribe to that user's order updates
-		messageChan, err := orderSvc.SubscribeUserOrders(r.Context(), user.Id)
+		conn.SetReadDeadline(time.Now().Add(120 * time.Second))
+		conn.SetPongHandler(func(appData string) error {
+			conn.SetReadDeadline(time.Now().Add(120 * time.Second)) // Extend deadline on pong
+			return nil
+		})
+
+		messageChan, err := orderSvc.SubscribeUserOrders(ctx, user.Id)
 		if err != nil {
-			logctx.Error(r.Context(), "error subscribing to user orders", logger.Error(err))
+			logctx.Error(ctx, "error subscribing to user orders", logger.Error(err), logger.String("userId", user.Id.String()))
 			http.Error(w, "Error subscribing to orders", http.StatusInternalServerError)
 			return
 		}
 
-		// Read messages from the channel and send to WebSocket
-		for msg := range messageChan {
-			if err := conn.WriteMessage(websocket.TextMessage, msg); err != nil {
-				logctx.Error(r.Context(), "error writing to websocket", logger.Error(err))
-				break
-			}
+		// Ensure Redis connection is unsubscribed and closed when the WebSocket disconnects
+		defer func() {
+			orderSvc.UnsubscribeUserOrders(ctx, user.Id, messageChan)
+		}()
 
+		ticker := time.NewTicker(60 * time.Second)
+		defer ticker.Stop()
+
+		for {
+			select {
+			case msg, ok := <-messageChan:
+				if !ok {
+					logctx.Warn(ctx, "message channel closed", logger.String("userId", user.Id.String()))
+					return
+				}
+				if err := conn.WriteMessage(websocket.TextMessage, msg); err != nil {
+					logctx.Warn(ctx, "unable to write to websocket", logger.Error(err), logger.String("userId", user.Id.String()))
+					return
+				}
+			case <-ticker.C:
+				if err := conn.WriteMessage(websocket.PingMessage, nil); err != nil {
+					logctx.Error(ctx, "error sending ping", logger.Error(err), logger.String("userId", user.Id.String()))
+					return
+				}
+			case <-ctx.Done():
+				logctx.Info(ctx, "request context cancelled", logger.String("userId", user.Id.String()))
+				return
+			}
 		}
 	}
 }


### PR DESCRIPTION
## How to test
1. `make up`
2. Add `API_KEY` env var
3. `python e2e/maker/main.py` (ensure you are in venv and have installed dependencies)
4. In another terminal, run `scripts/ws-test/multi-ws.py` to start multiple Websocket consumers. You can adjust `num_clients` to add more consumers